### PR TITLE
feat(Internal): add constant-time Eq, use Scoped for internals

### DIFF
--- a/sel/src/Sel/Internal.hs
+++ b/sel/src/Sel/Internal.hs
@@ -1,53 +1,104 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Sel.Internal where
 
+import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import qualified Data.Base16.Types as Base16
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Internal as BS
+import Control.Monad.Trans.Class (lift)
+import Data.Base16.Types qualified as Base16
+import Data.ByteString (StrictByteString)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Internal (memcmp)
+import Data.ByteString.Internal qualified as ByteString
+import Data.ByteString.Unsafe qualified as ByteString
+import Data.Coerce (coerce)
 import Data.Kind (Type)
-import Foreign (Ptr, castForeignPtr)
-import Foreign.C.Types (CInt (CInt), CSize (CSize))
-import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
-import LibSodium.Bindings.SecureMemory (sodiumFree, sodiumMalloc)
+import Foreign (ForeignPtr, Ptr)
+import Foreign qualified
+import Foreign.C (CSize, CUChar, throwErrno)
+import Foreign.C.Types (CChar)
+import LibSodium.Bindings.Comparison (sodiumMemcmp)
+import LibSodium.Bindings.SecureMemory (finalizerSodiumFree, sodiumFree, sodiumMalloc)
+import Sel.Internal.Scoped
+import Sel.Internal.Scoped.Foreign
 
--- | This calls to C's @memcmp@ function, used in lieu of
--- libsodium's @memcmp@ in cases when the return code is necessary.
-foreign import capi unsafe "string.h memcmp"
-  memcmp :: Ptr a -> Ptr b -> CSize -> IO CInt
+-- | Compare the contents of two byte arrays in constant time.
+--
+-- /See:/ [Constant-time test for equality](https://doc.libsodium.org/helpers#constant-time-test-for-equality)
+--
+-- @since 0.0.3.0
+foreignPtrEqConstantTime :: ForeignPtr CUChar -> ForeignPtr CUChar -> CSize -> IO Bool
+foreignPtrEqConstantTime p q size =
+  fmap (== 0) . use $
+    sodiumMemcmp <$> foreignPtr p <*> foreignPtr q <*> pure size
 
--- | Compare if the contents of two @ForeignPtr@s are equal.
-foreignPtrEq :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Bool
-foreignPtrEq fptr1 fptr2 size =
-  withForeignPtr fptr1 $ \p ->
-    withForeignPtr fptr2 $ \q ->
-      do
-        result <- memcmp p q size
-        return $ 0 == result
+-- | Lexicographically compare the contents of two byte arrays.
+--
+-- ⚠️ Such comparisons are vulnerable to timing attacks, and should be
+-- avoided for secret data.
+--
+-- @since 0.0.1.0
+foreignPtrOrd :: ForeignPtr CUChar -> ForeignPtr CUChar -> CSize -> IO Ordering
+foreignPtrOrd p q size =
+  fmap (`compare` 0) . useM $
+    memcmp
+      <$> foreignPtr (coerce p)
+      <*> foreignPtr (coerce q)
+      <*> pure (fromIntegral size)
 
--- | Compare the contents of two @ForeignPtr@s using lexicographical ordering.
-foreignPtrOrd :: ForeignPtr a -> ForeignPtr a -> CSize -> IO Ordering
-foreignPtrOrd fptr1 fptr2 size =
-  withForeignPtr fptr1 $ \p ->
-    withForeignPtr fptr2 $ \q ->
-      do
-        result <- memcmp p q size
-        return $
-          if
-            | result == 0 -> EQ
-            | result < 0 -> LT
-            | otherwise -> GT
+-- | Compare two byte arrays for lexicographic equality.
+--
+-- ⚠️ Such comparisons are vulnerable to timing attacks, and should be
+-- avoided for secret data.
+--
+-- @since 0.0.1.0
+foreignPtrEq :: ForeignPtr CUChar -> ForeignPtr CUChar -> CSize -> IO Bool
+foreignPtrEq p q size = (== EQ) <$> foreignPtrOrd p q size
 
+-- | Convert a @'ForeignPtr' a@ to a 'ByteString' of the given length
+-- and render the hexadecimal-encoded bytes as a 'String'.
+--
+-- @since 0.0.1.0
 foreignPtrShow :: ForeignPtr a -> CSize -> String
-foreignPtrShow fptr size =
-  BS.unpackChars . Base16.extractBase16 . Base16.encodeBase16' $
-    BS.fromForeignPtr (Foreign.castForeignPtr fptr) 0 (fromIntegral @CSize @Int size)
+foreignPtrShow (Foreign.castForeignPtr -> cstring) size =
+  ByteString.unpackChars . Base16.extractBase16 . Base16.encodeBase16' $
+    ByteString.fromForeignPtr cstring 0 (fromIntegral size)
+
+-- | Copy a byte array as key material.
+--
+-- The size of the array is not checked. The input may be truncated if
+-- it is too long, or an unchecked exception may be thrown if it is
+-- too short.
+--
+-- @since 0.0.3.0
+unsafeCopyToSodiumPointer :: CSize -> StrictByteString -> IO (ForeignPtr CUChar)
+unsafeCopyToSodiumPointer size s = use $ do
+  str <- unsafeCString s
+  lift $ sodiumPointer size $ \k ->
+    Foreign.copyArray
+      (Foreign.castPtr @CUChar @CChar k)
+      str
+      (fromIntegral @CSize @Int size)
+
+-- | Allocate memory for key material and populate it with the provided action.
+--
+-- Memory is allocated with 'LibSodium.Bindings.SecureMemory.sodiumMalloc' (see notes).
+--
+-- A finalizer frees the memory when the key goes out of scope.
+--
+-- @since 0.0.3.0
+sodiumPointer :: CSize -> (Ptr CUChar -> IO ()) -> IO (ForeignPtr CUChar)
+sodiumPointer size action = do
+  ptr <- sodiumMalloc size
+  when (ptr == Foreign.nullPtr) $ do
+    throwErrno "sodium_malloc"
+  action ptr
+  Foreign.newForeignPtr finalizerSodiumFree ptr
 
 -- | Securely allocate an amount of memory with 'sodiumMalloc' and pass
 -- a pointer to the region to the provided action.


### PR DESCRIPTION
Constant-time comparison helps avoid timing attacks on secret cryptographic material.

Also adds functions for interacting with `sodium_malloc`'d pointers.