### PR TITLE
feat(Signature): refactor and expand public-key signature API

### DIFF
--- a/sel/sel.cabal
+++ b/sel/sel.cabal
@@ -54,6 +54,7 @@ library
     Sel.HMAC.SHA256
     Sel.HMAC.SHA512
     Sel.HMAC.SHA512_256
+    Sel.KeyMaterialDecodeError
     Sel.PublicKey.Cipher
     Sel.PublicKey.Seal
     Sel.PublicKey.Signature
@@ -66,6 +67,7 @@ library
     Sel.Internal
     Sel.Internal.Scoped
     Sel.Internal.Scoped.Foreign
+    Sel.PublicKey.Internal.Signature
 
   build-depends:
     , base                >=4.14   && <5

--- a/sel/src/Sel/Hashing/Short.hs
+++ b/sel/src/Sel/Hashing/Short.hs
@@ -55,7 +55,6 @@ import qualified Data.Text.Lazy.Builder as Builder
 import Foreign hiding (void)
 import Foreign.C (CSize, CUChar, CULLong)
 import GHC.Exception (Exception)
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import qualified Data.Base16.Types as Base16
@@ -250,7 +249,7 @@ binaryToShortHashKey binaryKey =
       BS.unsafeUseAsCString binaryKey $ \cString -> do
         shortHashKeyFPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoShortHashSipHashX24KeyBytes)
         Foreign.withForeignPtr shortHashKeyFPtr $ \shortHashKeyPtr ->
-          memcpy shortHashKeyPtr (Foreign.castPtr cString) cryptoShortHashSipHashX24KeyBytes
+          Foreign.copyBytes shortHashKeyPtr (Foreign.castPtr cString) (fromIntegral cryptoShortHashSipHashX24KeyBytes)
         pure $ Just $ ShortHashKey shortHashKeyFPtr
 
 -- | Convert a strict hexadecimal-encoded 'Text' to a 'ShortHashKey'.

--- a/sel/src/Sel/KeyMaterialDecodeError.hs
+++ b/sel/src/Sel/KeyMaterialDecodeError.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- Module      : Sel.KeyMaterialDecodeError
+-- Description : Key material utilities
+-- Copyright   : (c) Jack Henahan, 2024
+-- License     : BSD-3-Clause
+-- Maintainer  : The Haskell Cryptography Group
+-- Portability : GHC only
+module Sel.KeyMaterialDecodeError
+  ( -- * Key material utilities
+    KeyMaterialDecodeError (..)
+  , RequiredLength (..)
+  , InputLength (..)
+  , validKeyMaterial
+  )
+where
+
+import Control.Exception (Exception)
+import Data.Bifunctor (first)
+import Data.ByteString (StrictByteString)
+import Data.ByteString qualified as ByteString
+import Data.ByteString.Base16 qualified as Base16
+import Data.Coerce (coerce)
+import Data.Text (Text)
+import Data.Text.Display (Display, ShowInstance (..))
+import Foreign.C (CSize (..))
+
+-- | Errors arising from decoding key material from bytes.
+--
+-- @since 0.0.3.0
+data KeyMaterialDecodeError
+  = -- | Input length does not match the length required for the target pointer.
+    --
+    -- @since 0.0.3.0
+    ByteLengthMismatch RequiredLength InputLength
+  | -- | Input bytes did not decode to hexadecimal.
+    --
+    -- @since 0.0.3.0
+    DecodingFailure Text
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+    , Eq
+      -- ^ @since 0.0.3.0
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+    )
+    via (ShowInstance KeyMaterialDecodeError)
+  deriving anyclass
+    ( Exception
+      -- ^ @since 0.0.3.0
+    )
+
+-- | The length of the target pointer for some key material.
+--
+-- @since 0.0.3.0
+newtype RequiredLength = RequiredLength Int
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+    , Eq
+      -- ^ @since 0.0.3.0
+    )
+
+-- | The length of some input bytes.
+--
+-- @since 0.0.3.0
+newtype InputLength = InputLength Int
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+    , Eq
+      -- ^ @since 0.0.3.0
+    )
+
+-- | Attempt to decode a hexadecimal-encoded 'StrictByteString'
+validKeyMaterial :: CSize -> StrictByteString -> Either KeyMaterialDecodeError StrictByteString
+validKeyMaterial (fromIntegral -> requiredLength) bytes = do
+  decoded@(ByteString.length -> inputLength) <-
+    first DecodingFailure (Base16.decodeBase16Untyped bytes)
+  if requiredLength == inputLength
+    then Right decoded
+    else Left $ ByteLengthMismatch (coerce requiredLength) (coerce inputLength)

--- a/sel/src/Sel/PublicKey/Cipher.hs
+++ b/sel/src/Sel/PublicKey/Cipher.hs
@@ -64,7 +64,6 @@ import Foreign (ForeignPtr, Ptr)
 import qualified Foreign
 import Foreign.C (CChar, CSize, CUChar, CULLong)
 import qualified Foreign.C as Foreign
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import Control.Exception
@@ -496,10 +495,10 @@ decrypt
               (-1) -> pure Nothing
               _ -> do
                 bsPtr <- Foreign.mallocBytes (fromIntegral messageLength)
-                memcpy bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
+                Foreign.copyBytes bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
                 Just
                   <$> BS.unsafePackMallocCStringLen
-                    (Foreign.castPtr @CChar bsPtr, fromIntegral messageLength)
+                    (Foreign.castPtr @CUChar @CChar bsPtr, fromIntegral messageLength)
 
 -- | Exception thrown upon error during the generation of
 -- the key pair by 'newKeyPair'.

--- a/sel/src/Sel/PublicKey/Internal/Signature.hs
+++ b/sel/src/Sel/PublicKey/Internal/Signature.hs
@@ -1,0 +1,499 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Sel.PublicKey.Internal.Signature
+  ( -- ** Public Keys
+    type PublicKey
+  , decodePublicKeyHexByteString
+  , encodePublicKeyHexByteString
+
+    -- ** Secret Keys
+  , type SecretKey
+  , decodeSecretKeyHexByteString
+  , encodeSecretKeyHexByteString
+  , UnsafeSecretKey (..)
+  , publicKey
+
+    -- ** Key Pairs
+  , KeyPair (..)
+  , public
+  , secret
+  , keyPair
+
+    -- ** Signed Messages
+  , type SignedMessage
+  , sign
+  , open
+  , SignatureVerification (..)
+  , extractUnverifiedMessage
+  , extractSignature
+  , buildSignedMessage
+
+    -- ** Exceptions
+  , PublicKeyExtractionException (..)
+  )
+where
+
+import Control.Exception (Exception, throw)
+import Control.Monad (unless)
+import Control.Monad.Trans.Class (lift)
+import Data.Base16.Types qualified as Base16
+import Data.ByteString (StrictByteString)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Internal qualified as ByteString
+import Data.ByteString.Unsafe qualified as ByteString
+import Data.Coerce (coerce)
+import Data.Ord (comparing)
+import Data.Text.Display (Display, OpaqueInstance (..), ShowInstance (..))
+import Data.Traversable (for)
+import Foreign (ForeignPtr)
+import Foreign qualified
+import Foreign.C (CChar, CSize, CUChar, CULLong)
+import LibSodium.Bindings.CryptoSign
+  ( cryptoSignBytes
+  , cryptoSignDetached
+  , cryptoSignED25519SkToPk
+  , cryptoSignKeyPair
+  , cryptoSignPublicKeyBytes
+  , cryptoSignSecretKeyBytes
+  , cryptoSignVerifyDetached
+  )
+import Sel.Internal
+  ( foreignPtrEq
+  , foreignPtrEqConstantTime
+  , foreignPtrOrd
+  , unsafeCopyToSodiumPointer
+  )
+import Sel.Internal.Scoped
+import Sel.Internal.Scoped.Foreign
+  ( copyArray
+  , foreignPtr
+  , mallocBytes
+  , mallocForeignPtrBytes
+  , unsafeCString
+  , unsafeCStringLen
+  )
+import Sel.KeyMaterialDecodeError
+import System.IO.Unsafe (unsafeDupablePerformIO)
+
+-- | A public key of size 'cryptoSignPublicKeyBytes', suitable for
+-- publication to third parties for message verification.
+--
+-- @since 0.0.1.0
+newtype PublicKey = PublicKey (ForeignPtr CUChar)
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- Hexadecimal-encoded bytes.
+    )
+    via (ShowInstance PublicKey)
+
+-- | By lexicographical comparison of pointer contents.
+--
+-- @since 0.0.1.0
+instance Eq PublicKey where
+  a == b =
+    foreignPtrEq (coerce a) (coerce b) cryptoSignPublicKeyBytes
+
+-- | By lexicographical comparison of pointer contents.
+--
+-- @since 0.0.1.0
+instance Ord PublicKey where
+  a `compare` b =
+    foreignPtrOrd (coerce a) (coerce b) cryptoSignPublicKeyBytes
+
+-- | Hexadecimal-encoded bytes.
+--
+-- @since 0.0.3.0
+instance Show PublicKey where
+  show = ByteString.unpackChars . encodePublicKeyHexByteString
+
+-- | Decode a hexadecimal-encoded 'StrictByteString' to a t'PublicKey'
+-- using the default copying decoder.
+--
+-- @since 0.0.3.0
+decodePublicKeyHexByteString :: StrictByteString -> Either KeyMaterialDecodeError PublicKey
+decodePublicKeyHexByteString bytes = PublicKey <$> copyHexKey cryptoSignPublicKeyBytes bytes
+
+-- | Encode a t'PublicKey' to a hexadecimal encoded 'StrictByteString'
+-- using the default copying encoder.
+--
+-- @since 0.0.3.0
+encodePublicKeyHexByteString :: PublicKey -> StrictByteString
+encodePublicKeyHexByteString (PublicKey publicKeyPtr) =
+  Base16.extractBase16 . Base16.encodeBase16' $
+    ByteString.fromForeignPtr0
+      (Foreign.castForeignPtr publicKeyPtr)
+      (fromIntegral cryptoSignPublicKeyBytes)
+
+-- | A secret key of size 'cryptoSignSecretKeyBytes'. Keep this private.
+--
+-- @since 0.0.1.0
+newtype SecretKey = SecretKey (ForeignPtr CUChar)
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- > display secretKey == "[REDACTED]"
+    )
+    via (OpaqueInstance "[REDACTED]" SecretKey)
+
+-- | By constant-time comparison of pointer contents.
+--
+-- @since 0.0.3.0
+instance Eq SecretKey where
+  a == b =
+    foreignPtrEqConstantTime (coerce a) (coerce b) cryptoSignSecretKeyBytes
+
+-- | > show secretKey == "[REDACTED]"
+--
+-- @since 0.0.3.0
+instance Show SecretKey where
+  show _ = "[REDACTED]"
+
+-- | Decode a hexadecimal-encoded 'StrictByteString' to a t'SecretKey'
+-- using the default copying decoder.
+--
+-- @since 0.0.3.0
+decodeSecretKeyHexByteString :: StrictByteString -> Either KeyMaterialDecodeError SecretKey
+decodeSecretKeyHexByteString bytes = SecretKey <$> copyHexKey cryptoSignSecretKeyBytes bytes
+
+-- | Encode an t'UnsafeSecretKey' to a hexadecimal encoded
+-- 'StrictByteString' using the default copying encoder.
+--
+-- @since 0.0.3.0
+encodeSecretKeyHexByteString :: UnsafeSecretKey -> StrictByteString
+encodeSecretKeyHexByteString (UnsafeSecretKey (SecretKey secretKeyPtr)) =
+  Base16.extractBase16 . Base16.encodeBase16' $
+    ByteString.fromForeignPtr0
+      (Foreign.castForeignPtr secretKeyPtr)
+      (fromIntegral cryptoSignSecretKeyBytes)
+
+-- | Produce the t'PublicKey' from a t'SecretKey'.
+--
+-- This function may throw a t'PublicKeyExtractionException' if the operation fails.
+publicKey :: SecretKey -> PublicKey
+publicKey (SecretKey secretKeyPtr) = unsafeDupablePerformIO $ do
+  publicKeyPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoSignPublicKeyBytes)
+  res <-
+    useM $
+      cryptoSignED25519SkToPk
+        <$> foreignPtr publicKeyPtr
+        <*> foreignPtr secretKeyPtr
+  unless (res == 0) $ throw PublicKeyExtractionException
+  pure $ PublicKey publicKeyPtr
+
+-- | Signal your intent to encode secret key material for transmission
+-- by wrapping a t'SecretKey' in t'UnsafeSecretKey'.
+--
+-- @since 0.0.3.0
+newtype UnsafeSecretKey = UnsafeSecretKey SecretKey
+  deriving newtype
+    ( Eq
+      -- ^ @since 0.0.3.0
+      -- Follows the t'SecretKey' instance.
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- Hexadecimal-encoded bytes.
+    )
+    via (ShowInstance UnsafeSecretKey)
+
+-- | Hexadecimal-encoded bytes.
+--
+-- @since 0.0.3.0
+instance Show UnsafeSecretKey where
+  show = ByteString.unpackChars . encodeSecretKeyHexByteString
+
+-- | By lexicographical comparison of pointer contents.
+--
+-- ⚠️ Vulnerable to timing attacks!
+--
+-- @since 0.0.3.0
+instance Ord UnsafeSecretKey where
+  a `compare` b =
+    foreignPtrOrd (coerce a) (coerce b) cryptoSignSecretKeyBytes
+
+-- | A signing key pair, comprising a t'PublicKey' and a t'SecretKey'.
+--
+-- @since 0.0.3.0
+data KeyPair = KeyPair {public :: PublicKey, secret :: SecretKey}
+  deriving stock
+    ( Show
+      -- ^ @since 0.0.3.0
+      -- Follows the instances for t'PublicKey' and t'SecretKey', respectively.
+      --
+      -- In particular, the secret key will be shown as @[REDACTED]@.
+    , Eq
+      -- ^ @since 0.0.3.0
+      -- Follows the instances for t'PublicKey' and t'SecretKey', respectively.
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+      -- Follows the instances for t'PublicKey' and t'SecretKey', respectively.
+      --
+      -- In particular, the secret key will be displayed as @[REDACTED]@.
+    )
+    via (ShowInstance KeyPair)
+
+-- | By lexicographical comparison of key pointer contents.
+--
+-- ⚠️ Vulnerable to timing attacks!
+--
+-- @since 0.0.3.0
+instance Ord KeyPair where
+  compare kp1 kp2 =
+    compare kp1.public kp2.public
+      <> comparing UnsafeSecretKey kp1.secret kp2.secret
+
+-- | The t'PublicKey' in a t'KeyPair'.
+--
+-- @since 0.0.3.0
+public :: KeyPair -> PublicKey
+public = (.public)
+
+-- | The t'SecretKey' in a t'KeyPair'.
+--
+-- @since 0.0.3.0
+secret :: KeyPair -> SecretKey
+secret = (.secret)
+
+-- | Generate a fresh t'KeyPair'.
+--
+-- @since 0.0.3.0
+keyPair :: IO KeyPair
+keyPair = do
+  publicKeyPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoSignPublicKeyBytes)
+  secretKeyPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoSignSecretKeyBytes)
+  useM_ $ cryptoSignKeyPair <$> foreignPtr publicKeyPtr <*> foreignPtr secretKeyPtr
+  pure $ KeyPair (PublicKey publicKeyPtr) (SecretKey secretKeyPtr)
+
+-- | A message of known length together with its signature of length
+-- 'cryptoSignBytes'.
+--
+-- @since 0.0.1.0
+data SignedMessage = SignedMessage
+  { messageLength :: CSize
+  -- ^ Original message length
+  , messageForeignPtr :: ForeignPtr CUChar
+  , signatureForeignPtr :: ForeignPtr CUChar
+  }
+
+-- | > show message = "SignedMessage { message = \"<contents>\", signature = \"<signature>\" }"
+--
+-- @since 0.0.3.0
+instance Show SignedMessage where
+  show msg = unsafeDupablePerformIO $ use $ do
+    message <- extractUnverifiedMessage msg
+    sig <- extractSignature msg
+    let showMessage = ByteString.unpackChars message
+        showSig = ByteString.unpackChars . Base16.extractBase16 . Base16.encodeBase16' $ sig
+    pure $
+      mconcat
+        [ "SignedMessage { message = \""
+        , showMessage
+        , "\", signature = \""
+        , showSig
+        , "\" }"
+        ]
+
+-- | By message length, then lexicographical comparison of message and
+-- signature pointer contents.
+--
+-- @since 0.0.1.0
+instance Eq SignedMessage where
+  (SignedMessage len1 msg1 sig1) == (SignedMessage len2 msg2 sig2) =
+    let
+      messageLength = len1 == len2
+      messageEq = foreignPtrEq msg1 msg2 len1
+      signatureEq = foreignPtrEq sig1 sig2 cryptoSignBytes
+     in
+      messageLength && messageEq && signatureEq
+
+-- | By message length, then lexicographical comparison of message and
+-- signature pointer contents.
+--
+-- @since 0.0.1.0
+instance Ord SignedMessage where
+  compare (SignedMessage len1 msg1 sig1) (SignedMessage len2 msg2 sig2) =
+    let
+      messageLength = compare len1 len2
+      messageOrd = foreignPtrOrd msg1 msg2 len1
+      signatureOrd = foreignPtrOrd sig1 sig2 cryptoSignBytes
+     in
+      messageLength <> messageOrd <> signatureOrd
+
+-- | Sign a message with a t'SecretKey'.
+sign :: SecretKey -> StrictByteString -> Scoped IO SignedMessage
+sign (SecretKey secretKeyForeignPtr) message = do
+  (cstring, messageLength) <- unsafeCStringLen message
+  messageForeignPtr <- mallocForeignPtrBytes messageLength
+  signatureForeignPtr <- mallocForeignPtrBytes (fromIntegral @CSize @Int cryptoSignBytes)
+  reset $ do
+    messagePtr <- foreignPtr messageForeignPtr
+    copyArray messagePtr (Foreign.castPtr @CChar @CUChar cstring) messageLength
+    signaturePtr <- foreignPtr signatureForeignPtr
+    secretKeyPtr <- foreignPtr secretKeyForeignPtr
+    lift $
+      cryptoSignDetached
+        signaturePtr
+        Foreign.nullPtr
+        (Foreign.castPtr @CChar @CUChar cstring)
+        (fromIntegral @Int @CULLong messageLength)
+        secretKeyPtr
+  pure
+    SignedMessage
+      { messageLength = fromIntegral @Int @CSize messageLength
+      , messageForeignPtr
+      , signatureForeignPtr
+      }
+
+-- | Result of detached signature verification.
+--
+-- @since 0.0.3.0
+data SignatureVerification a
+  = -- | The signature was created by the expected t'SecretKey'.
+    --
+    -- @since 0.0.3.0
+    Valid a
+  | -- | The signature was not created by the expected t'SecretKey'.
+    --
+    -- @since 0.0.3.0
+    Invalid
+  deriving stock
+    ( Eq
+      -- ^ @since 0.0.3.0
+    , Ord
+      -- ^ @since 0.0.3.0
+    , Show
+      -- ^ @since 0.0.3.0
+    , Functor
+      -- ^ @since 0.0.3.0
+    , Foldable
+      -- ^ @since 0.0.3.0
+    , Traversable
+      -- ^ @since 0.0.3.0
+    )
+  deriving
+    ( Display
+      -- ^ @since 0.0.3.0
+    )
+    via (ShowInstance (SignatureVerification a))
+
+-- | Verify that a message was signed by the t'SecretKey' corresponding
+-- to the given t'PublicKey'.
+--
+-- @since 0.0.3.0
+verify :: SignedMessage -> PublicKey -> Scoped IO (SignatureVerification SignedMessage)
+verify message (PublicKey publicKeyForeignPtr) = do
+  result <- reset $ do
+    publicKeyPtr <- foreignPtr publicKeyForeignPtr
+    signaturePtr <- foreignPtr message.signatureForeignPtr
+    messagePtr <- foreignPtr message.messageForeignPtr
+    lift $
+      cryptoSignVerifyDetached
+        signaturePtr
+        messagePtr
+        (fromIntegral @CSize @CULLong message.messageLength)
+        publicKeyPtr
+  pure $ if result == 0 then Valid message else Invalid
+
+-- | Attempt to extract the message from a t'SignedMessage', verifying
+-- that the message was signed with the t'SecretKey' corresponding to
+-- the given t'PublicKey'.
+--
+-- @since 0.0.3.0
+open :: SignedMessage -> PublicKey -> Scoped IO (SignatureVerification StrictByteString)
+open message key = traverse extractUnverifiedMessage =<< verify message key
+
+-- | Extract a part of a t'SignedMessage' without verifying the signature.
+--
+-- @since 0.0.3.0
+unverifiedExtract
+  :: (SignedMessage -> ForeignPtr CUChar)
+  -> CSize
+  -> SignedMessage
+  -> Scoped IO StrictByteString
+unverifiedExtract target fieldLength (target -> field) = do
+  fieldPtr <- foreignPtr field
+  bsPtr <- mallocBytes (fromIntegral fieldLength)
+  lift $ Foreign.copyBytes bsPtr fieldPtr (fromIntegral fieldLength)
+  lift $ do
+    ByteString.unsafePackMallocCStringLen
+      ( Foreign.castPtr @_ @CChar bsPtr
+      , fromIntegral fieldLength
+      )
+
+-- | Extract the message part of a t'SignedMessage' without verifying the signature.
+--
+-- @since 0.0.3.0
+extractUnverifiedMessage :: SignedMessage -> Scoped IO StrictByteString
+extractUnverifiedMessage msg = unverifiedExtract (.messageForeignPtr) msg.messageLength msg
+
+-- | Extract the signature part of a t'SignedMessage' without verifying the signature.
+--
+-- @since 0.0.3.0
+extractSignature :: SignedMessage -> Scoped IO StrictByteString
+extractSignature = unverifiedExtract (.signatureForeignPtr) cryptoSignBytes
+
+-- | Construct a t'SignedMessage' from the message contents and a detached signature.
+--
+-- @since 0.0.3.0
+buildSignedMessage :: StrictByteString -> StrictByteString -> Scoped IO SignedMessage
+buildSignedMessage message signature = do
+  (messageString, messageLength) <- unsafeCStringLen message
+  messageForeignPtr <- mallocForeignPtrBytes messageLength
+  signatureForeignPtr <- mallocForeignPtrBytes (fromIntegral cryptoSignBytes)
+  reset $ do
+    signatureString <- unsafeCString signature
+    messagePtr <- foreignPtr messageForeignPtr
+    signaturePtr <- foreignPtr signatureForeignPtr
+    copyArray messagePtr (Foreign.castPtr messageString) messageLength
+    copyArray signaturePtr (Foreign.castPtr signatureString) (fromIntegral cryptoSignBytes)
+  pure
+    SignedMessage
+      { messageLength = fromIntegral @Int @CSize messageLength
+      , messageForeignPtr
+      , signatureForeignPtr
+      }
+
+-- | Thrown when we fail to extract a t'PublicKey' from a t'SecretKey'.
+--
+-- @since 0.0.3.0
+data PublicKeyExtractionException = PublicKeyExtractionException
+  deriving stock
+    ( Eq
+      -- ^ @since 0.0.3.0
+    , Ord
+      -- ^ @since 0.0.3.0
+    , Show
+      -- ^ @since 0.0.3.0
+    )
+  deriving anyclass
+    ( Exception
+      -- ^ @since 0.0.3.0
+    )
+
+-- | Copy a hexadecimal-encoded bytestring to some key pointer.
+--
+-- Input is checked for encoding and length.
+--
+-- @since 0.0.3.0
+copyHexKey :: CSize -> StrictByteString -> Either KeyMaterialDecodeError (ForeignPtr CUChar)
+copyHexKey size bytes =
+  unsafeDupablePerformIO $
+    for (validKeyMaterial size bytes) (unsafeCopyToSodiumPointer size)

--- a/sel/src/Sel/PublicKey/Seal.hs
+++ b/sel/src/Sel/PublicKey/Seal.hs
@@ -38,11 +38,21 @@ import Data.ByteString (StrictByteString)
 import qualified Data.ByteString.Unsafe as BS
 import qualified Foreign
 import Foreign.C (CChar, CSize, CUChar, CULLong)
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
-import LibSodium.Bindings.SealedBoxes (cryptoBoxSeal, cryptoBoxSealOpen, cryptoBoxSealbytes)
-import Sel.PublicKey.Cipher (CipherText (CipherText), EncryptionError (..), KeyPairGenerationException, PublicKey (PublicKey), SecretKey (..), newKeyPair)
+import LibSodium.Bindings.SealedBoxes
+  ( cryptoBoxSeal
+  , cryptoBoxSealOpen
+  , cryptoBoxSealbytes
+  )
+import Sel.PublicKey.Cipher
+  ( CipherText (CipherText)
+  , EncryptionError (..)
+  , KeyPairGenerationException
+  , PublicKey (PublicKey)
+  , SecretKey (..)
+  , newKeyPair
+  )
 
 -- $introduction
 -- Ephemeral authenticated encryption allows to anonymously send message to
@@ -133,7 +143,7 @@ open
             (-1) -> pure Nothing
             _ -> do
               bsPtr <- Foreign.mallocBytes (fromIntegral messageLen)
-              memcpy bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLen)
+              Foreign.copyBytes bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLen)
               Just
                 <$> BS.unsafePackMallocCStringLen
-                  (Foreign.castPtr @CChar bsPtr, fromIntegral messageLen)
+                  (Foreign.castPtr @CUChar @CChar bsPtr, fromIntegral messageLen)

--- a/sel/src/Sel/PublicKey/Signature.hs
+++ b/sel/src/Sel/PublicKey/Signature.hs
@@ -1,240 +1,235 @@
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-
 -- |
 --
 -- Module: Sel.PublicKey.Signature
 -- Description: Public-key signatures with the Ed25519 algorithm
--- Copyright: (C) Hécate Moonlight 2022
+-- Copyright: (C) Hécate Moonlight 2022, Jack Henahan 2024
 -- License: BSD-3-Clause
 -- Maintainer: The Haskell Cryptography Group
 -- Portability: GHC only
 module Sel.PublicKey.Signature
-  ( -- ** Introduction
+  ( -- * Public-key Signatures
     -- $introduction
+
+    -- ** Public keys
+    -- $publicKeys
     PublicKey
+  , decodePublicKeyHexByteString
+  , encodePublicKeyHexByteString
+
+    -- ** Secret keys
+    -- $secretKeys
   , SecretKey
-  , SignedMessage
+  , decodeSecretKeyHexByteString
+  , encodeSecretKeyHexByteString
+  , publicKey
+
+    -- *** ⚠️ Handle with care
+  , UnsafeSecretKey (..)
+  , unsafeSecretKeyHexByteString
 
     -- ** Key Pair generation
+  , KeyPair (..)
+  , public
+  , secret
+  , keyPair
+
+    -- *** Deprecated functions
   , generateKeyPair
 
     -- ** Message Signing
+  , SignedMessage
+  , signWith
   , signMessage
-  , openMessage
 
-    -- ** Constructing and Deconstructing
+    -- *** Inspecting signed messages
+  , verifiedMessage
+  , SignatureVerification (..)
+  , signature
+  , unverifiedMessage
+
+    -- *** Detached signatures
+  , signedMessage
+
+    -- *** Deprecated functions
+  , openMessage
   , getSignature
   , unsafeGetMessage
   , mkSignature
+
+    -- ** Exceptions
+  , PublicKeyExtractionException (..)
   )
 where
 
-import Control.Monad (void)
 import Data.ByteString (StrictByteString)
-import Data.ByteString.Unsafe (unsafePackMallocCStringLen)
-import qualified Data.ByteString.Unsafe as ByteString
-import Foreign
-  ( ForeignPtr
-  , Ptr
-  , castPtr
-  , mallocBytes
-  , mallocForeignPtrBytes
-  , withForeignPtr
-  )
-import Foreign.C (CChar, CSize, CUChar, CULLong)
-import qualified Foreign.Marshal.Array as Foreign
-import qualified Foreign.Ptr as Foreign
-import GHC.IO.Handle.Text (memcpy)
+import Sel.Internal.Scoped (use)
+import Sel.PublicKey.Internal.Signature
 import System.IO.Unsafe (unsafeDupablePerformIO)
-
-import LibSodium.Bindings.CryptoSign
-  ( cryptoSignBytes
-  , cryptoSignDetached
-  , cryptoSignKeyPair
-  , cryptoSignPublicKeyBytes
-  , cryptoSignSecretKeyBytes
-  , cryptoSignVerifyDetached
-  )
-import Sel.Internal
 
 -- $introduction
 --
--- Public-key Signatures work with a 'SecretKey' and 'PublicKey'
+-- Append a signature to any number of messages using a
+-- t'SecretKey'. Distribute a t'PublicKey' so third-parties can verify
+-- that the messages were signed with a particular t'SecretKey'.
 --
--- * The 'SecretKey' is used to append a signature to any number of messages. It must stay private;
--- * The 'PublicKey' is used by third-parties to to verify that the signature appended to a message was
--- issued by the creator of the public key. It must be distributed to third-parties.
+-- * The t'SecretKey' must stay private.
 --
--- Verifiers need to already know and ultimately trust a public key before messages signed
--- using it can be verified.
+-- * The t'PublicKey' is not a proof of identity, only control. Ensure
+-- that t'PublicKey's are trusted before verifying signatures.
 
--- |
+-- $publicKeys
 --
--- @since 0.0.1.0
-newtype PublicKey = PublicKey (ForeignPtr CUChar)
+-- Public keys are intended to be shared with any party or process
+-- which may need to verify that a given message was signed by a
+-- particular secret key.
+--
+-- === Human-readable output
+--
+-- * @'Data.Text.Display.display' :: t'PublicKey' -> 'Data.Text.Text'@, the hexadecimal encoding of the t'PublicKey' in a 'Data.Text.Text'
+-- * @'show' :: t'PublicKey' -> 'String'@, the hexadecimal encoding of the t'PublicKey' in a 'String'
 
--- |
+-- $secretKeys
 --
--- @since 0.0.1.0
-instance Eq PublicKey where
-  (PublicKey pk1) == (PublicKey pk2) =
-    foreignPtrEq pk1 pk2 cryptoSignPublicKeyBytes
+-- Secret keys are intended to be private and never shared without
+-- extreme care. Leaking a secret key allows anyone to impersonate the
+-- creator of that key and sign messages with their identity.
+--
+-- If a secret key is compromised, all messages signed by that key
+-- should be considered compromised.
+--
+-- Secret keys are compared for equality using the constant-time
+-- 'LibSodium.Bindings.Comparison.sodiumMemcmp' to avoid timing attacks.
+--
+-- __NB:__ Prefer being explicit with t'UnsafeSecretKey' to signal your
+-- intent to transmit sensitive key material.
+--
+-- === ⚠️ Serialization
+--
+-- * @'encodeSecretKeyHexByteString' :: t'UnsafeSecretKey' -> 'StrictBytestring'@
+-- * @'unsafeSecretKeyHexByteString' :: t'SecretKey' -> 'StrictByteString'@
+--
+-- === ⚠️ Human-readable output
+--
+-- * @'Text.Display.display' :: t'UnsafeSecretKey' -> 'Data.Text.Text'@, the hexadecimal encoding of the wrapped t'SecretKey' in a 'Data.Text.Text'
+-- * @'show' :: t'UnsafeSecretKey' -> 'String'@, the hexadecimal encoding of the wrapped t'SecretKey' in a 'String'
 
--- |
+-- | Convert a t'SecretKey' to a hexadecimal-encoded 'StrictByteString'.
 --
--- @since 0.0.1.0
-instance Ord PublicKey where
-  compare (PublicKey pk1) (PublicKey pk2) =
-    foreignPtrOrd pk1 pk2 cryptoSignPublicKeyBytes
+-- ⚠️ Serializing secret keys is a security risk. Be careful how you
+-- use the output of this function.
+--
+-- @since 0.0.3.0
+unsafeSecretKeyHexByteString :: SecretKey -> StrictByteString
+unsafeSecretKeyHexByteString = encodeSecretKeyHexByteString . UnsafeSecretKey
 
--- |
+-- | Sign a message with a t'SecretKey'.
 --
--- @since 0.0.1.0
-newtype SecretKey = SecretKey (ForeignPtr CUChar)
+-- === Example
+--
+-- Given @messages :: 'Traversable' t => t 'StrictByteString'@ and
+-- @key :: t'SecretKey'@, we can sign each message with our key.
+--
+-- @
+--   traverse (signWith key) messages -- :: Traversable t => IO (t SignedMessage)
+--   -- or, equivalently
+--   for messages (signWith key)
+-- @
+--
+-- @since 0.0.3.0
+signWith :: SecretKey -> StrictByteString -> IO SignedMessage
+signWith secretKey message = use $ sign secretKey message
 
--- |
+-- | Sign a message with a t'SecretKey'.
 --
--- @since 0.0.1.0
-instance Eq SecretKey where
-  (SecretKey sk1) == (SecretKey sk2) =
-    foreignPtrEqConstantTime sk1 sk2 cryptoSignSecretKeyBytes
-
--- |
+-- === Example
 --
--- @since 0.0.1.0
-instance Ord SecretKey where
-  compare (SecretKey sk1) (SecretKey sk2) =
-    foreignPtrOrd sk1 sk2 cryptoSignSecretKeyBytes
-
--- |
+-- Given @keys :: 'Traversable' t => t t'SecretKey'@ and @message ::
+-- 'StrictByteString'@, we can sign our message with each key.
 --
--- @since 0.0.1.0
-data SignedMessage = SignedMessage
-  { messageLength :: CSize
-  , messageForeignPtr :: ForeignPtr CUChar
-  , signatureForeignPtr :: ForeignPtr CUChar
-  }
-
--- |
---
--- @since 0.0.1.0
-instance Eq SignedMessage where
-  (SignedMessage len1 msg1 sig1) == (SignedMessage len2 msg2 sig2) =
-    let
-      messageLength = len1 == len2
-      msg1Eq = foreignPtrEq msg1 msg2 len1
-      msg2Eq = foreignPtrEq sig1 sig2 cryptoSignBytes
-     in
-      messageLength && msg1Eq && msg2Eq
-
--- |
---
--- @since 0.0.1.0
-instance Ord SignedMessage where
-  compare (SignedMessage len1 msg1 sig1) (SignedMessage len2 msg2 sig2) =
-    let
-      messageLength = compare len1 len2
-      msg1Ord = foreignPtrOrd msg1 msg2 len1
-      msg2Ord = foreignPtrOrd sig1 sig2 cryptoSignBytes
-     in
-      messageLength <> msg1Ord <> msg2Ord
-
--- | Generate a pair of public and secret key.
---
--- The length parameters used are 'cryptoSignPublicKeyBytes'
--- and 'cryptoSignSecretKeyBytes'.
---
--- @since 0.0.1.0
-generateKeyPair :: IO (PublicKey, SecretKey)
-generateKeyPair = do
-  publicKeyForeignPtr <- mallocForeignPtrBytes (fromIntegral @CSize @Int cryptoSignPublicKeyBytes)
-  secretKeyForeignPtr <- mallocForeignPtrBytes (fromIntegral @CSize @Int cryptoSignSecretKeyBytes)
-  withForeignPtr publicKeyForeignPtr $ \pkPtr ->
-    withForeignPtr secretKeyForeignPtr $ \skPtr ->
-      void $
-        cryptoSignKeyPair
-          pkPtr
-          skPtr
-  pure (PublicKey publicKeyForeignPtr, SecretKey secretKeyForeignPtr)
-
--- | Sign a message.
+-- @
+--   traverse (signMessage message) keys -- :: Traversable t => IO (t 'SignedMessage')
+--   -- or, equivalently
+--   for keys (signMessage message)
+-- @
 --
 -- @since 0.0.1.0
 signMessage :: StrictByteString -> SecretKey -> IO SignedMessage
-signMessage message (SecretKey skFPtr) =
-  ByteString.unsafeUseAsCStringLen message $ \(cString, messageLength) -> do
-    let sigLength = fromIntegral @CSize @Int cryptoSignBytes
-    (messageForeignPtr :: ForeignPtr CUChar) <- Foreign.mallocForeignPtrBytes messageLength
-    signatureForeignPtr <- Foreign.mallocForeignPtrBytes sigLength
-    withForeignPtr messageForeignPtr $ \messagePtr ->
-      withForeignPtr signatureForeignPtr $ \signaturePtr ->
-        withForeignPtr skFPtr $ \skPtr -> do
-          Foreign.copyArray messagePtr (Foreign.castPtr @CChar @CUChar cString) messageLength
-          void $
-            cryptoSignDetached
-              signaturePtr
-              Foreign.nullPtr -- Always of size 'cryptoSignBytes'
-              (castPtr @CChar @CUChar cString)
-              (fromIntegral @Int @CULLong messageLength)
-              skPtr
-    pure $ SignedMessage (fromIntegral @Int @CSize messageLength) messageForeignPtr signatureForeignPtr
+signMessage = flip signWith
 
--- | Open a signed message with the signatory's public key.
--- The function returns 'Nothing' if there is a key mismatch.
+-- | Attempt to extract the message from a t'SignedMessage', verifying
+-- that the message was signed with the t'SecretKey' corresponding to
+-- the given t'PublicKey'.
+--
+-- @since 0.0.3.0
+verifiedMessage :: SignedMessage -> PublicKey -> SignatureVerification StrictByteString
+verifiedMessage message key = unsafeDupablePerformIO . use $ open message key
+
+-- | Get the signature part of a t'SignedMessage'.
+--
+-- @since 0.0.3.0
+signature :: SignedMessage -> StrictByteString
+signature = unsafeDupablePerformIO . use . extractSignature
+
+-- | Get the message part of a t'SignedMessage' __without verifying the signature__.
+--
+-- @since 0.0.3.0
+unverifiedMessage :: SignedMessage -> StrictByteString
+unverifiedMessage = unsafeDupablePerformIO . use . extractUnverifiedMessage
+
+-- | Construct a signed message from a message and a detached signature.
+--
+-- @since 0.0.3.0
+signedMessage :: StrictByteString -> StrictByteString -> SignedMessage
+signedMessage messageBytes signatureBytes =
+  unsafeDupablePerformIO . use $
+    buildSignedMessage messageBytes signatureBytes
+
+{- Deprecated API -}
+
+{- KeyPair -}
+{-# DEPRECATED generateKeyPair "Prefer 'keyPair'" #-}
+
+-- | Generate a pair of public and secret key.
+--
+-- The length parameters used are 'LibSodium.Bindings.CryptoSign.cryptoSignPublicKeyBytes'
+-- and 'LibSodium.Bindings.CryptoSign.cryptoSignSecretKeyBytes'.
+--
+-- @since 0.0.1.0
+generateKeyPair :: IO (PublicKey, SecretKey)
+generateKeyPair = (,) <$> public <*> secret <$> keyPair
+
+{- SignedMessage -}
+{-# DEPRECATED openMessage "Prefer 'verifiedMessage'" #-}
+{-# DEPRECATED getSignature "Prefer 'signature'" #-}
+{-# DEPRECATED unsafeGetMessage "Prefer 'unverifiedMessage'" #-}
+{-# DEPRECATED mkSignature "Prefer 'signedMessage'" #-}
+
+-- | Attempt to extract a the message from a t'SignedMessage',
+-- verifying that the message was signed with the t'SecretKey'
+-- corresponding to the given t'PublicKey', yielding `Nothing` if the
+-- key is not applicable.
 --
 -- @since 0.0.1.0
 openMessage :: SignedMessage -> PublicKey -> Maybe StrictByteString
-openMessage SignedMessage{messageLength, messageForeignPtr, signatureForeignPtr} (PublicKey pkForeignPtr) = unsafeDupablePerformIO $
-  withForeignPtr pkForeignPtr $ \publicKeyPtr ->
-    withForeignPtr signatureForeignPtr $ \signaturePtr -> do
-      withForeignPtr messageForeignPtr $ \messagePtr -> do
-        result <-
-          cryptoSignVerifyDetached
-            signaturePtr
-            messagePtr
-            (fromIntegral @CSize @CULLong messageLength)
-            publicKeyPtr
-        case result of
-          (-1) -> pure Nothing
-          _ -> do
-            bsPtr <- mallocBytes (fromIntegral messageLength)
-            memcpy bsPtr (castPtr messagePtr) messageLength
-            Just <$> unsafePackMallocCStringLen (castPtr bsPtr :: Ptr CChar, fromIntegral messageLength)
+openMessage message key =
+  case verifiedMessage message key of
+    Valid msg -> Just msg
+    Invalid -> Nothing
 
--- | Get the signature part of a 'SignedMessage'.
+-- | Get the signature part of a t'SignedMessage'.
 --
 -- @since 0.0.1.0
 getSignature :: SignedMessage -> StrictByteString
-getSignature SignedMessage{signatureForeignPtr} = unsafeDupablePerformIO $
-  withForeignPtr signatureForeignPtr $ \signaturePtr -> do
-    bsPtr <- Foreign.mallocBytes (fromIntegral cryptoSignBytes)
-    memcpy bsPtr signaturePtr cryptoSignBytes
-    unsafePackMallocCStringLen (Foreign.castPtr bsPtr :: Ptr CChar, fromIntegral cryptoSignBytes)
+getSignature = signature
 
--- | Get the message part of a 'SignedMessage' __without verifying the signature__.
+-- | Get the message part of a t'SignedMessage' __without verifying the signature__.
 --
 -- @since 0.0.1.0
 unsafeGetMessage :: SignedMessage -> StrictByteString
-unsafeGetMessage SignedMessage{messageLength, messageForeignPtr} = unsafeDupablePerformIO $
-  withForeignPtr messageForeignPtr $ \messagePtr -> do
-    bsPtr <- Foreign.mallocBytes (fromIntegral messageLength)
-    memcpy bsPtr messagePtr messageLength
-    unsafePackMallocCStringLen (Foreign.castPtr bsPtr :: Ptr CChar, fromIntegral messageLength)
+unsafeGetMessage = unverifiedMessage
 
--- | Combine a message and a signature into a 'SignedMessage'.
+-- | Construct a signed message from a message and a detached signature.
 --
 -- @since 0.0.1.0
 mkSignature :: StrictByteString -> StrictByteString -> SignedMessage
-mkSignature message signature = unsafeDupablePerformIO $
-  ByteString.unsafeUseAsCStringLen message $ \(messageStringPtr, messageLength) ->
-    ByteString.unsafeUseAsCStringLen signature $ \(signatureStringPtr, _) -> do
-      (messageForeignPtr :: ForeignPtr CUChar) <- Foreign.mallocForeignPtrBytes messageLength
-      signatureForeignPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoSignBytes)
-      withForeignPtr messageForeignPtr $ \messagePtr ->
-        withForeignPtr signatureForeignPtr $ \signaturePtr -> do
-          Foreign.copyArray messagePtr (Foreign.castPtr messageStringPtr) messageLength
-          Foreign.copyArray signaturePtr (Foreign.castPtr signatureStringPtr) (fromIntegral cryptoSignBytes)
-      pure $ SignedMessage (fromIntegral @Int @CSize messageLength) messageForeignPtr signatureForeignPtr
+mkSignature = signedMessage

--- a/sel/src/Sel/SecretKey/Cipher.hs
+++ b/sel/src/Sel/SecretKey/Cipher.hs
@@ -57,7 +57,6 @@ import Data.Word (Word8)
 import Foreign (ForeignPtr)
 import qualified Foreign
 import Foreign.C (CChar, CSize, CUChar, CULLong, throwErrno)
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import LibSodium.Bindings.Random (randombytesBuf)
@@ -417,7 +416,7 @@ decrypt Hash{messageLength, hashForeignPtr} (SecretKey secretKeyForeignPtr) (Non
           (-1) -> pure Nothing
           _ -> do
             bsPtr <- Foreign.mallocBytes (fromIntegral messageLength)
-            memcpy bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
+            Foreign.copyBytes bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
             Just
               <$> BS.unsafePackMallocCStringLen
                 (Foreign.castPtr @CChar bsPtr, fromIntegral messageLength)

--- a/sel/test/Test/PublicKey/Signature.hs
+++ b/sel/test/Test/PublicKey/Signature.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.PublicKey.Signature where
@@ -5,20 +6,84 @@ module Test.PublicKey.Signature where
 import Sel.PublicKey.Signature
 import Test.Tasty
 import Test.Tasty.HUnit
+import TestUtils
 
 spec :: TestTree
-spec =
-  testGroup
-    "Signing tests"
-    [ testCase "Sign a message with a public key and decrypt it with a secret key" testSignMessage
-    ]
+spec = withKeyPair $ \kp ->
+  testGroup "Signature" $
+    sequence [serdes, signing] kp
 
-testSignMessage :: Assertion
-testSignMessage = do
-  (publicKey, secretKey) <- generateKeyPair
-  signedMessage <- signMessage "hello hello" secretKey
-  let result = openMessage signedMessage publicKey
+serdes :: IO KeyPair -> TestTree
+serdes kp =
+  testGroup "Key pair serdes" $
+    keyPairCases
+      kp
+      [ ("Public key round-trip", publicKeyRoundTrip)
+      , ("Secret key round-trip", secretKeyRoundTrip)
+      , ("Public key extraction", publicKeyExtraction)
+      ]
+
+signing :: IO KeyPair -> TestTree
+signing kp =
+  testGroup "Message signing" $
+    keyPairCases
+      kp
+      [ ("Sign and open with the same key", signAndOpenSelf)
+      , ("Sign and open with another key", signAndOpenOther)
+      , ("Detached signature round-trip", signRoundTrip)
+      ]
+
+keyPairCases :: IO KeyPair -> [(String, KeyPair -> Assertion)] -> [TestTree]
+keyPairCases = fmap . uncurry . usingKeyPair
+
+withKeyPair :: (IO KeyPair -> TestTree) -> TestTree
+withKeyPair = withResource keyPair mempty
+
+usingKeyPair :: IO KeyPair -> String -> (KeyPair -> Assertion) -> TestTree
+usingKeyPair kp testName test = testCase testName (test =<< kp)
+
+publicKeyRoundTrip :: KeyPair -> Assertion
+publicKeyRoundTrip kp = do
+  let encoded = encodePublicKeyHexByteString kp.public
+  decoded <- assertRight $ decodePublicKeyHexByteString encoded
+  assertEqual "Public key hex decode" kp.public decoded
+
+secretKeyRoundTrip :: KeyPair -> Assertion
+secretKeyRoundTrip kp = do
+  let encoded = encodeSecretKeyHexByteString $ UnsafeSecretKey kp.secret
+  decoded <- assertRight $ decodeSecretKeyHexByteString encoded
+  assertEqual "Secret key hex decode" kp.secret decoded
+
+publicKeyExtraction :: KeyPair -> Assertion
+publicKeyExtraction kp =
+  assertEqual "Public key extraction" kp.public (publicKey kp.secret)
+
+signAndOpenSelf :: KeyPair -> Assertion
+signAndOpenSelf kp = do
+  let message = "SIGNED"
+  signed <- signWith kp.secret message
+  let result = verifiedMessage signed kp.public
   assertEqual
-    "Message is well-opened with the correct key"
-    (Just "hello hello")
+    "Open self-signed message"
+    (Valid message)
     result
+
+signAndOpenOther :: KeyPair -> Assertion
+signAndOpenOther kp = do
+  let message = "SIGNED"
+  other <- keyPair
+  signed <- signWith kp.secret message
+  let result = verifiedMessage signed other.public
+  assertEqual
+    "Fail to open with another key"
+    Invalid
+    result
+
+signRoundTrip :: KeyPair -> Assertion
+signRoundTrip kp = do
+  let message = "SIGNED"
+  signed <- signWith kp.secret message
+  let unverified = unverifiedMessage signed
+      detachedSignature = signature signed
+      reconstructed = signedMessage unverified detachedSignature
+  assertEqual "Round trip" signed reconstructed


### PR DESCRIPTION
Highlights:

- Models input validation errors (pointer length and hex encoding)

- Serde and rendering functions for `PublicKey`, `SecretKey`, and `SignedMessage`

- Internals under `Scoped`

- Uses constant-time `Eq` for `SecretKey`