### PR TITLE
refactor: migrate to Foreign.copyBytes

### DIFF
--- a/sel/src/Sel/Hashing/Short.hs
+++ b/sel/src/Sel/Hashing/Short.hs
@@ -55,7 +55,6 @@ import qualified Data.Text.Lazy.Builder as Builder
 import Foreign hiding (void)
 import Foreign.C (CSize, CUChar, CULLong)
 import GHC.Exception (Exception)
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import qualified Data.Base16.Types as Base16
@@ -250,7 +249,7 @@ binaryToShortHashKey binaryKey =
       BS.unsafeUseAsCString binaryKey $ \cString -> do
         shortHashKeyFPtr <- Foreign.mallocForeignPtrBytes (fromIntegral cryptoShortHashSipHashX24KeyBytes)
         Foreign.withForeignPtr shortHashKeyFPtr $ \shortHashKeyPtr ->
-          memcpy shortHashKeyPtr (Foreign.castPtr cString) cryptoShortHashSipHashX24KeyBytes
+          Foreign.copyBytes shortHashKeyPtr (Foreign.castPtr cString) (fromIntegral cryptoShortHashSipHashX24KeyBytes)
         pure $ Just $ ShortHashKey shortHashKeyFPtr
 
 -- | Convert a strict hexadecimal-encoded 'Text' to a 'ShortHashKey'.

--- a/sel/src/Sel/PublicKey/Cipher.hs
+++ b/sel/src/Sel/PublicKey/Cipher.hs
@@ -64,7 +64,6 @@ import Foreign (ForeignPtr, Ptr)
 import qualified Foreign
 import Foreign.C (CChar, CSize, CUChar, CULLong)
 import qualified Foreign.C as Foreign
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import Control.Exception
@@ -496,10 +495,10 @@ decrypt
               (-1) -> pure Nothing
               _ -> do
                 bsPtr <- Foreign.mallocBytes (fromIntegral messageLength)
-                memcpy bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
+                Foreign.copyBytes bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
                 Just
                   <$> BS.unsafePackMallocCStringLen
-                    (Foreign.castPtr @CChar bsPtr, fromIntegral messageLength)
+                    (Foreign.castPtr @CUChar @CChar bsPtr, fromIntegral messageLength)
 
 -- | Exception thrown upon error during the generation of
 -- the key pair by 'newKeyPair'.

--- a/sel/src/Sel/PublicKey/Seal.hs
+++ b/sel/src/Sel/PublicKey/Seal.hs
@@ -38,11 +38,21 @@ import Data.ByteString (StrictByteString)
 import qualified Data.ByteString.Unsafe as BS
 import qualified Foreign
 import Foreign.C (CChar, CSize, CUChar, CULLong)
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
-import LibSodium.Bindings.SealedBoxes (cryptoBoxSeal, cryptoBoxSealOpen, cryptoBoxSealbytes)
-import Sel.PublicKey.Cipher (CipherText (CipherText), EncryptionError (..), KeyPairGenerationException, PublicKey (PublicKey), SecretKey (..), newKeyPair)
+import LibSodium.Bindings.SealedBoxes
+  ( cryptoBoxSeal
+  , cryptoBoxSealOpen
+  , cryptoBoxSealbytes
+  )
+import Sel.PublicKey.Cipher
+  ( CipherText (CipherText)
+  , EncryptionError (..)
+  , KeyPairGenerationException
+  , PublicKey (PublicKey)
+  , SecretKey (..)
+  , newKeyPair
+  )
 
 -- $introduction
 -- Ephemeral authenticated encryption allows to anonymously send message to
@@ -133,7 +143,7 @@ open
             (-1) -> pure Nothing
             _ -> do
               bsPtr <- Foreign.mallocBytes (fromIntegral messageLen)
-              memcpy bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLen)
+              Foreign.copyBytes bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLen)
               Just
                 <$> BS.unsafePackMallocCStringLen
-                  (Foreign.castPtr @CChar bsPtr, fromIntegral messageLen)
+                  (Foreign.castPtr @CUChar @CChar bsPtr, fromIntegral messageLen)

--- a/sel/src/Sel/SecretKey/Cipher.hs
+++ b/sel/src/Sel/SecretKey/Cipher.hs
@@ -57,7 +57,6 @@ import Data.Word (Word8)
 import Foreign (ForeignPtr)
 import qualified Foreign
 import Foreign.C (CChar, CSize, CUChar, CULLong, throwErrno)
-import GHC.IO.Handle.Text (memcpy)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 import LibSodium.Bindings.Random (randombytesBuf)
@@ -417,7 +416,7 @@ decrypt Hash{messageLength, hashForeignPtr} (SecretKey secretKeyForeignPtr) (Non
           (-1) -> pure Nothing
           _ -> do
             bsPtr <- Foreign.mallocBytes (fromIntegral messageLength)
-            memcpy bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
+            Foreign.copyBytes bsPtr (Foreign.castPtr messagePtr) (fromIntegral messageLength)
             Just
               <$> BS.unsafePackMallocCStringLen
                 (Foreign.castPtr @CChar bsPtr, fromIntegral messageLength)


### PR DESCRIPTION
For consistency, use `Foreign.copyBytes` everywhere that `memcpy` was once used.